### PR TITLE
implement get token API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,24 @@ var context = new MilkContext(apyKey, sharedSecret);
 var authorizer = new MilkAuthorizer(context);
 
 // get frob
-var frob = await authorizer.GetFrob();
+var (frob, fail) = await authorizer.GetFrob();
+if (fail != null)
+{
+    // if API call is failed, you can get error information
+    // from `MilkFailureResponse` object
+    throw new Exception($"API call is failed | code: {fail.Code}, msg: {fail.Msg}");
+}
 
-// generate authentication URL
-var url = authorizer.GenerateAuthenticationUrl(frob);
+// generate authentication URL with "delete" permission
+var authUrl = authorizer.GenerateAuthUrl(MilkPerms.Delete, frob);
 
 // open authentication URL on your web browser
 
 // get token
-var token = await authorizer.GetToken(frob);
+var (authToken, _) = await authorizer.GetToken(frob);
 
-context.Token = token;
+// set token to context
+context.AuthToken = authToken;
 ```
 
 ## Licence

--- a/sample/MilkSharp.Sample.ConsoleApp/Program.cs
+++ b/sample/MilkSharp.Sample.ConsoleApp/Program.cs
@@ -45,7 +45,7 @@ namespace MilkSharp.Sample.ConsoleApp
 
             Console.ReadKey();
 
-            var (authToken, _) = await authorizer.GekToken(frob);
+            var (authToken, _) = await authorizer.GetToken(frob);
             Console.WriteLine($"token: {authToken.Token}, perms: {authToken.Perms}");
         }
 

--- a/sample/MilkSharp.Sample.ConsoleApp/Program.cs
+++ b/sample/MilkSharp.Sample.ConsoleApp/Program.cs
@@ -41,9 +41,12 @@ namespace MilkSharp.Sample.ConsoleApp
 
             OpenUrlOnDefaultWebBrowser(authUrl);
 
-            Console.WriteLine("Please authenticate with the web page.");
+            Console.WriteLine("Please authenticate with the web page, and push any key.");
 
             Console.ReadKey();
+
+            var (authToken, _) = await authorizer.GekToken(frob);
+            Console.WriteLine($"token: {authToken.Token}, perms: {authToken.Perms}");
         }
 
         private static void OpenUrlOnDefaultWebBrowser(string authUrl)

--- a/sample/MilkSharp.Sample.ConsoleApp/Program.cs
+++ b/sample/MilkSharp.Sample.ConsoleApp/Program.cs
@@ -33,7 +33,12 @@ namespace MilkSharp.Sample.ConsoleApp
             Console.WriteLine(rsp["foo"]);
 
             var authorizer = new MilkAuthorizer(context);
-            var (frob, _) = await authorizer.GetFrob();
+
+            var (frob, fail) = await authorizer.GetFrob();
+            if (fail != null)
+            {
+                throw new Exception($"API call is failed | code: {fail.Code}, msg: {fail.Msg}");
+            }
             Console.WriteLine($"frob:{frob}");
 
             var authUrl = authorizer.GenerateAuthUrl(MilkPerms.Delete, frob);
@@ -47,6 +52,8 @@ namespace MilkSharp.Sample.ConsoleApp
 
             var (authToken, _) = await authorizer.GetToken(frob);
             Console.WriteLine($"token: {authToken.Token}, perms: {authToken.Perms}");
+
+            context.AuthToken = authToken;
         }
 
         private static void OpenUrlOnDefaultWebBrowser(string authUrl)

--- a/src/MilkSharp/MilkAuthToken.cs
+++ b/src/MilkSharp/MilkAuthToken.cs
@@ -1,9 +1,32 @@
-﻿namespace MilkSharp
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace MilkSharp
 {
     public class MilkAuthToken
     {
         public MilkAuthToken()
         {
         }
+
+        private MilkAuthToken(string token, MilkPerms perms)
+        {
+            Token = token;
+            Perms = perms;
+        }
+
+        public static MilkAuthToken Parse(string rawRsp)
+        {
+            var rspXml = XElement.Parse(rawRsp);
+            var auth = rspXml.Element("auth");
+            return new MilkAuthToken(
+                auth.Element("token").Value,
+                MilkPerms.FromValue(auth.Element("perms").Value)
+                );
+
+        }
+
+        public string Token { get; }
+        public MilkPerms Perms { get; }
     }
 }

--- a/src/MilkSharp/MilkAuthorizer.cs
+++ b/src/MilkSharp/MilkAuthorizer.cs
@@ -50,5 +50,18 @@ namespace MilkSharp
                 });
             return $"https://www.rememberthemilk.com/services/auth/?api_key={context.ApiKey}&perms={perms}&frob={frob}&api_sig={signature}";
         }
+
+        public async Task<(MilkAuthToken token, MilkFailureResponse fail)> GekToken(string frob)
+        {
+            var (rawRsp, failureResponse) = await milkCoreClient.Invoke(
+                "rtm.auth.getToken",
+                new Dictionary<string, string>{
+                    { "frob", frob }
+                });
+
+            if (failureResponse != null) return (null, failureResponse);
+
+            return (MilkAuthToken.Parse(rawRsp), null);
+        }
     }
 }

--- a/src/MilkSharp/MilkAuthorizer.cs
+++ b/src/MilkSharp/MilkAuthorizer.cs
@@ -51,7 +51,7 @@ namespace MilkSharp
             return $"https://www.rememberthemilk.com/services/auth/?api_key={context.ApiKey}&perms={perms}&frob={frob}&api_sig={signature}";
         }
 
-        public async Task<(MilkAuthToken token, MilkFailureResponse fail)> GekToken(string frob)
+        public async Task<(MilkAuthToken token, MilkFailureResponse fail)> GetToken(string frob)
         {
             var (rawRsp, failureResponse) = await milkCoreClient.Invoke(
                 "rtm.auth.getToken",

--- a/src/MilkSharp/MilkPerms.cs
+++ b/src/MilkSharp/MilkPerms.cs
@@ -1,4 +1,6 @@
-﻿namespace MilkSharp
+﻿using System;
+
+namespace MilkSharp
 {
     public class MilkPerms
     {
@@ -18,5 +20,12 @@
             return value;
         }
 
+        public static MilkPerms FromValue(string value)
+        {
+            return value == Read.value ? Read
+                : value == Write.value ? Write
+                : value == Delete.value ? Delete
+                : throw new ArgumentOutOfRangeException(nameof(value));
+        }
     }
 }

--- a/test/MilkSharp.Test/AuthorizationTest.cs
+++ b/test/MilkSharp.Test/AuthorizationTest.cs
@@ -107,7 +107,7 @@ namespace MilkSharp.Test
                 var authorizer = new MilkAuthorizer(milkCoreClient);
 
                 var frob = "frob123";
-                (MilkAuthToken authToken, MilkFailureResponse fail) = await authorizer.GekToken(frob);
+                (MilkAuthToken authToken, MilkFailureResponse fail) = await authorizer.GetToken(frob);
 
                 Assert.Equal("410c57262293e9d937ee5be75eb7b0128fd61b61", authToken.Token);
                 Assert.Equal(MilkPerms.Delete, authToken.Perms);

--- a/test/MilkSharp.Test/AuthorizationTest.cs
+++ b/test/MilkSharp.Test/AuthorizationTest.cs
@@ -78,6 +78,40 @@ namespace MilkSharp.Test
 
                 Assert.Equal("https://www.rememberthemilk.com/services/auth/?api_key=api123&perms=delete&frob=frob123&api_sig=sig123", authUrl);
             }
+
+            [Fact]
+            public async void GetTokenTest()
+            {
+                var milkCoreClientMock = new Mock<IMilkCoreClient>();
+
+                milkCoreClientMock
+                    .Setup(client => client.Invoke(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>()))
+                    .Callback<string, IDictionary<string, string>>((method, parameters) =>
+                    {
+                        Assert.Equal("rtm.auth.getToken", method);
+                        Assert.Equal("frob123", parameters["frob"]);
+                    })
+                    .Returns(() => Task.FromResult<(string, MilkFailureResponse)>((
+                        @"
+                            <rsp stat=""ok"">
+                                <auth>
+                                    <token>410c57262293e9d937ee5be75eb7b0128fd61b61</token>
+                                    <perms>delete</perms>
+                                    <user id=""1"" username=""bob"" fullname=""Bob T. Monkey"" />
+                                </auth>
+                            </rsp>
+                        ",
+                        null)));
+                var milkCoreClient = milkCoreClientMock.Object;
+
+                var authorizer = new MilkAuthorizer(milkCoreClient);
+
+                var frob = "frob123";
+                (MilkAuthToken authToken, MilkFailureResponse fail) = await authorizer.GekToken(frob);
+
+                Assert.Equal("410c57262293e9d937ee5be75eb7b0128fd61b61", authToken.Token);
+                Assert.Equal(MilkPerms.Delete, authToken.Perms);
+            }
         }
     }
 }


### PR DESCRIPTION
add `GetToken` method as [`rtm.auth.getToken`](https://www.rememberthemilk.com/services/api/methods/rtm.auth.getToken.rtm) API wrapper.

- [x] `src/MilkSharp/MilkAuthorizer`
    - add `GetToken` method
- [x] `sample/MilkSharp.Sample.ConsoleApp/Program.cs`
    - use `GetToken` method
- [x] `README.md`
    - update **Usage - Authentication**